### PR TITLE
Updating rise requirements and explained a git ssh windows issue

### DIFF
--- a/_extras/common-issues.md
+++ b/_extras/common-issues.md
@@ -126,6 +126,30 @@ $ git config --global core.editor "nano -w"
 ~~~
 {: .language-bash}
 
+
+## SSH key authentication issues with Windows Git
+
+Rather unhelpfully, Git for Windows will use it's own SSH instance by default 
+which will result in you getting errors such as the below even after adding your 
+SSH key correctly
+
+~~~
+PS > git clone git@github.com:https://github.com/ukaea-rse-training/python-intermediate-inflammation
+Cloning into 'python-intermediate-inflammation'...
+git@github.com: Permission denied (publickey).
+fatal: Could not read from remote repository.
+
+Please make sure you have the correct access rights
+and the repository exists.
+~~~
+
+The solution is to change the SSH instance used by default in newer versions of
+Windows with:
+
+~~~
+PS > git config --global core.sshCommand C:/windows/System32/OpenSSH/ssh.exe
+~~~
+
 ## Python, `pip`, `venv` & Installing Packages Issues
 
 ### Issues With Numpy (and Potentially Other Packages) on New M1 Macs

--- a/slides/README.md
+++ b/slides/README.md
@@ -15,13 +15,13 @@ python3 -m venv .venv  # it is important to use the dot prefix if you are creati
 pip install -r slides/requirements.txt 
 # launch jupyter from the top level of this repo, **not** in the slide
 # directory or else the relative figure links won't work
-jupyter-notebook
-# navigate to the slide file, open with notebook and edit.
+jupyter-notebook  # or `jupyter-lab`
+# navigate to the slide file, right click, "open with > notebook".
 ```
 
 Use the RISE extension to Jupyter to view the slides.
 This allows you to enter the slideshow from the Jupyter notebook web interface.
-There should be a button with a histogram on the Jupyter notebook toolbar
+There should be a "projector screen" button on the Jupyter notebook toolbar next to the kernel name
 (you might need to go to the 'View' menu to get the toolbar to show).
 Click the button, or press `Alt-r` to launch the RISE presentation view.
 Use spacebar to advance slides. Presenter view with `t`.

--- a/slides/README.md
+++ b/slides/README.md
@@ -16,7 +16,7 @@ pip install -r slides/requirements.txt
 # launch jupyter from the top level of this repo, **not** in the slide
 # directory or else the relative figure links won't work
 jupyter-notebook
-# navigate to the slide file and edit
+# navigate to the slide file, open with notebook and edit.
 ```
 
 Use the RISE extension to Jupyter to view the slides.

--- a/slides/requirements.txt
+++ b/slides/requirements.txt
@@ -1,3 +1,4 @@
 jupyter
 rise
+jupyterlab_rise
 jupytext

--- a/slides/requirements.txt
+++ b/slides/requirements.txt
@@ -1,4 +1,3 @@
 jupyter
-rise
 jupyterlab_rise
 jupytext


### PR DESCRIPTION
RISE seems to work with the new jupyterlab_rise dependency. Checked against Calum's changes in the Testing course which made a similar change.